### PR TITLE
Disable the 'recursion' warnings.

### DIFF
--- a/Memoize.pm
+++ b/Memoize.pm
@@ -9,6 +9,8 @@
 
 use strict; use warnings;
 
+no warnings 'recursion';
+
 package Memoize;
 our $VERSION = '1.13';
 


### PR DESCRIPTION
This suppresses the followings warnings:

```
Deep recursion on subroutine "Memoize::_memoizer" at (eval 12) line 1.
Deep recursion on anonymous subroutine at /usr/share/perl5/site_perl/Memoize.pm line 200.
Deep recursion on subroutine "Memoize::_memoizer" at (eval 12) line 1.
Deep recursion on subroutine "Memoize::_memoizer" at (eval 13) line 1.
Deep recursion on anonymous subroutine at /usr/share/perl5/site_perl/Memoize.pm line 200.
Deep recursion on subroutine "Memoize::_memoizer" at (eval 13) line 1.
```

Since Memoize is a module also intended for heavy recursive functions, it doesn't make sense to warn about deep recursion.